### PR TITLE
Compatibility with the Multigrid Projector

### DIFF
--- a/BlockLimiter/BlockLimiter.cs
+++ b/BlockLimiter/BlockLimiter.cs
@@ -11,6 +11,7 @@ using BlockLimiter.ProcessHandlers;
 using BlockLimiter.Punishment;
 using BlockLimiter.Settings;
 using BlockLimiter.Utility;
+using MultigridProjector.Api;
 using Newtonsoft.Json;
 using NLog;
 using Sandbox.Engine.Multiplayer;
@@ -49,8 +50,11 @@ namespace BlockLimiter
         public static IPluginManager PluginManager { get; private set; }
         public string timeDataPath = "";
 
+        public IMultigridProjectorApi MultigridProjectorApi;
+
         private void DoInit()
         {
+            MultigridProjectorApi = new MultigridProjectorTorchAgent(_sessionManager.CurrentSession);
 
             _limitHandlers = new List<ProcessHandlerBase>
             {
@@ -60,7 +64,7 @@ namespace BlockLimiter
             _processThreads = new List<Thread>();
             _processThread = new Thread(PluginProcessing);
             _processThread.Start();
-            
+
             MyMultiplayer.Static.ClientJoined += StaticOnClientJoined;
             MyCubeGrids.BlockBuilt += MyCubeGridsOnBlockBuilt;
             MySession.Static.Factions.FactionStateChanged += FactionsOnFactionStateChanged;
@@ -79,7 +83,7 @@ namespace BlockLimiter
             if (!BlockLimiterConfig.Instance.EnableLimits) return;
 
             if (!(entity is MyCubeGrid grid)) return;
-            
+
             if (grid.Projector != null||grid.IsPreview) return;
 
             var biggestGrid = Grid.GetBiggestGridInGroup(grid);
@@ -312,7 +316,7 @@ namespace BlockLimiter
         {
             BlockLimiterConfig.Instance.Load();
         }
-        
+
         private UserControl _control;
         private UserControl Control => _control ?? (_control = new PropertyGrid{ DataContext = BlockLimiterConfig.Instance});
         public UserControl GetControl()
@@ -416,7 +420,7 @@ namespace BlockLimiter
         }
 
         #region External Access
-        
+
         public static bool CheckLimits_future(MyObjectBuilder_CubeGrid[] grids, long id = 0)
         {
             if (grids.Length == 0 ||!BlockLimiterConfig.Instance.EnableLimits || Utilities.IsExcepted(id))
@@ -438,10 +442,10 @@ namespace BlockLimiter
         {
             return Block.CanAdd(blocks, id, out nonAllowedBlocks);
         }
-        
+
         #endregion
 
-        
+
     }
 
 

--- a/BlockLimiter/BlockLimiter.cs
+++ b/BlockLimiter/BlockLimiter.cs
@@ -64,7 +64,7 @@ namespace BlockLimiter
             _processThreads = new List<Thread>();
             _processThread = new Thread(PluginProcessing);
             _processThread.Start();
-
+            
             MyMultiplayer.Static.ClientJoined += StaticOnClientJoined;
             MyCubeGrids.BlockBuilt += MyCubeGridsOnBlockBuilt;
             MySession.Static.Factions.FactionStateChanged += FactionsOnFactionStateChanged;
@@ -83,7 +83,7 @@ namespace BlockLimiter
             if (!BlockLimiterConfig.Instance.EnableLimits) return;
 
             if (!(entity is MyCubeGrid grid)) return;
-
+            
             if (grid.Projector != null||grid.IsPreview) return;
 
             var biggestGrid = Grid.GetBiggestGridInGroup(grid);
@@ -316,7 +316,7 @@ namespace BlockLimiter
         {
             BlockLimiterConfig.Instance.Load();
         }
-
+        
         private UserControl _control;
         private UserControl Control => _control ?? (_control = new PropertyGrid{ DataContext = BlockLimiterConfig.Instance});
         public UserControl GetControl()
@@ -420,7 +420,7 @@ namespace BlockLimiter
         }
 
         #region External Access
-
+        
         public static bool CheckLimits_future(MyObjectBuilder_CubeGrid[] grids, long id = 0)
         {
             if (grids.Length == 0 ||!BlockLimiterConfig.Instance.EnableLimits || Utilities.IsExcepted(id))
@@ -442,10 +442,10 @@ namespace BlockLimiter
         {
             return Block.CanAdd(blocks, id, out nonAllowedBlocks);
         }
-
+        
         #endregion
 
-
+        
     }
 
 

--- a/BlockLimiter/BlockLimiter.csproj
+++ b/BlockLimiter/BlockLimiter.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,13 +38,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\GameBinaries\netstandard.dll</HintPath>
+      <HintPath>$(SolutionDir)\GameBinaries\netstandard.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\TorchBinaries\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)\TorchBinaries\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog">
       <HintPath>$(SolutionDir)\GameBinaries\NLog.dll</HintPath>
@@ -147,6 +148,10 @@
     <Compile Include="BlockLimiter.cs" />
     <Compile Include="Commands\Admin.cs" />
     <Compile Include="Commands\Player.cs" />
+    <Compile Include="MultigridProjectorApi\BlockLocation.cs" />
+    <Compile Include="MultigridProjectorApi\BlockState.cs" />
+    <Compile Include="MultigridProjectorApi\IMultigridProjectorApi.cs" />
+    <Compile Include="MultigridProjectorApi\MultigridProjectorTorchAgent.cs" />
     <Compile Include="Patch\BlockOwnershipTransfer.cs" />
     <Compile Include="Patch\GridChange.cs" />
     <Compile Include="Patch\MergeBlockPatch.cs" />

--- a/BlockLimiter/BlockLimiter.csproj
+++ b/BlockLimiter/BlockLimiter.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,13 +37,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\GameBinaries\netstandard.dll</HintPath>
+      <HintPath>..\GameBinaries\netstandard.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\TorchBinaries\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\TorchBinaries\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog">
       <HintPath>$(SolutionDir)\GameBinaries\NLog.dll</HintPath>

--- a/BlockLimiter/BlockLimiter.csproj
+++ b/BlockLimiter/BlockLimiter.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <LangVersion>latest</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/BlockLimiter/MultigridProjectorApi/BlockLocation.cs
+++ b/BlockLimiter/MultigridProjectorApi/BlockLocation.cs
@@ -1,0 +1,16 @@
+using VRageMath;
+
+namespace MultigridProjector.Api
+{
+    public readonly struct BlockLocation
+    {
+        public readonly int GridIndex;
+        public readonly Vector3I Position;
+
+        public BlockLocation(int gridIndex, Vector3I position)
+        {
+            GridIndex = gridIndex;
+            Position = position;
+        }
+    }
+}

--- a/BlockLimiter/MultigridProjectorApi/BlockLocation.cs
+++ b/BlockLimiter/MultigridProjectorApi/BlockLocation.cs
@@ -2,7 +2,7 @@ using VRageMath;
 
 namespace MultigridProjector.Api
 {
-    public readonly struct BlockLocation
+    public struct BlockLocation
     {
         public readonly int GridIndex;
         public readonly Vector3I Position;

--- a/BlockLimiter/MultigridProjectorApi/BlockState.cs
+++ b/BlockLimiter/MultigridProjectorApi/BlockState.cs
@@ -1,0 +1,24 @@
+namespace MultigridProjector.Api
+{
+    public enum BlockState
+    {
+        // Block state is still unknown, not determined by the background worker yet
+        Unknown = 0,
+
+        // The block is not buildable due to lack of connectivity or colliding objects
+        NotBuildable = 1,
+
+        // The block has not built yet and ready to be built (side connections are good and no colliding objects)
+        Buildable = 2,
+
+        // The block is being built, but not to the level required by the blueprint (needs more welding)
+        BeingBuilt = 4,
+
+        // The block has been built to the level required by the blueprint or more
+        // NOTE: Reserved for welder optimization, not used yet. All built blocks remain in BeingBuilt state, currently.
+        FullyBuilt = 8,
+
+        // There is mismatching block in the place of the projected block with a different definition than required by the blueprint
+        Mismatch = 128
+    }
+}

--- a/BlockLimiter/MultigridProjectorApi/IMultigridProjectorApi.cs
+++ b/BlockLimiter/MultigridProjectorApi/IMultigridProjectorApi.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using VRage.Game;
+using VRage.Game.ModAPI;
+using VRageMath;
+
+namespace MultigridProjector.Api
+{
+    public interface IMultigridProjectorApi
+    {
+        // Multigrid Projector version: 0.1.18
+        string Version { get; }
+
+        // Returns the number of subgrids in the active projection, returns zero if there is no projection
+        int GetSubgridCount(long projectorId);
+
+        // Returns the original grid builders the projection is based on, returns null if no blueprint is loaded
+        List<MyObjectBuilder_CubeGrid> GetOriginalGridBuilders(long projectorId);
+
+        // Returns the preview grid (aka hologram) for the given subgrid, it always exists if the projection is active, even if fully built
+        IMyCubeGrid GetPreviewGrid(long projectorId, int subgridIndex);
+
+        // Returns the already built grid for the given subgrid if there is any, null if not built yet (the first subgrid is always built)
+        IMyCubeGrid GetBuiltGrid(long projectorId, int subgridIndex);
+
+        // Returns the build state of a single projected block
+        BlockState GetBlockState(long projectorId, int subgridIndex, Vector3I position);
+
+        // Writes built state of the preview blocks into blockStates in a given subgrid and volume of cubes with the given state mask
+        bool GetBlockStates(Dictionary<Vector3I, BlockState> blockStates, long projectorId, int subgridIndex, BoundingBoxI box, int mask);
+
+        // Returns the base connections of the blueprint: base position => top subgrid and top part position (only those connected in the blueprint)
+        Dictionary<Vector3I, BlockLocation> GetBaseConnections(long projectorId, int subgridIndex);
+
+        // Returns the top connections of the blueprint: top position => base subgrid and base part position (only those connected in the blueprint)
+        Dictionary<Vector3I, BlockLocation> GetTopConnections(long projectorId, int subgridIndex);
+    }
+}

--- a/BlockLimiter/MultigridProjectorApi/MultigridProjectorTorchAgent.cs
+++ b/BlockLimiter/MultigridProjectorApi/MultigridProjectorTorchAgent.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Torch.API.Managers;
+using Torch.API.Plugins;
+using Torch.API.Session;
+using Torch.Managers;
+using VRage.Game;
+using VRage.Game.ModAPI;
+using VRageMath;
+
+namespace MultigridProjector.Api
+{
+    public class MultigridProjectorTorchAgent : IMultigridProjectorApi
+    {
+        public static readonly Guid PluginId = new Guid("d9359ba0-9a69-41c3-971d-eb5170adb97e");
+        public static readonly string CompatibleMajorVersion = "0.";
+        public readonly ITorchPlugin Plugin;
+        public readonly object Api;
+
+        public bool Available => Plugin != null;
+        public string Version { get; }
+
+        private readonly MethodInfo _miGetSubgridCount;
+        private readonly MethodInfo _miGetOriginalGridBuilders;
+        private readonly MethodInfo _miGetPreviewGrid;
+        private readonly MethodInfo _miGetBuiltGrid;
+        private readonly MethodInfo _miGetBlockState;
+        private readonly MethodInfo _miGetBlockStates;
+        private readonly MethodInfo _miGetBaseConnections;
+        private readonly MethodInfo _miGetTopConnections;
+
+        public MultigridProjectorTorchAgent(ITorchSession torchSession)
+        {
+            var pluginManager = torchSession.Managers.GetManager<PluginManager>();
+            if (!pluginManager.Plugins.TryGetValue(PluginId, out var plugin))
+                return;
+
+            Api = plugin.GetType().GetProperty("Api")?.GetValue(plugin);
+            if (Api == null)
+                return;
+
+            var apiType = Api.GetType();
+            Version = (string) apiType.GetProperty("Version")?.GetValue(Api);
+            if (Version == null || !Version.StartsWith(CompatibleMajorVersion))
+                return;
+
+            _miGetSubgridCount = apiType.GetMethod("GetSubgridCount", BindingFlags.Instance | BindingFlags.Public);
+            _miGetOriginalGridBuilders = apiType.GetMethod("GetOriginalGridBuilders", BindingFlags.Instance | BindingFlags.Public);
+            _miGetPreviewGrid = apiType.GetMethod("GetPreviewGrid", BindingFlags.Instance | BindingFlags.Public);
+            _miGetBuiltGrid = apiType.GetMethod("GetBuiltGrid", BindingFlags.Instance | BindingFlags.Public);
+            _miGetBlockState = apiType.GetMethod("GetBlockState", BindingFlags.Instance | BindingFlags.Public);
+            _miGetBlockStates = apiType.GetMethod("GetBlockStates", BindingFlags.Instance | BindingFlags.Public);
+            _miGetBaseConnections = apiType.GetMethod("GetBaseConnections", BindingFlags.Instance | BindingFlags.Public);
+            _miGetTopConnections = apiType.GetMethod("GetTopConnections", BindingFlags.Instance | BindingFlags.Public);
+
+            Plugin = plugin;
+        }
+
+        public int GetSubgridCount(long projectorId)
+        {
+            return (int) (_miGetSubgridCount?.Invoke(Api, new object[] {projectorId}) ?? 0);
+        }
+
+        public List<MyObjectBuilder_CubeGrid> GetOriginalGridBuilders(long projectorId)
+        {
+            return (List<MyObjectBuilder_CubeGrid>) _miGetOriginalGridBuilders?.Invoke(Api, new object[] {projectorId});
+        }
+
+        public IMyCubeGrid GetPreviewGrid(long projectorId, int subgridIndex)
+        {
+            return (IMyCubeGrid) _miGetPreviewGrid?.Invoke(Api, new object[] {projectorId, subgridIndex});
+        }
+
+        public IMyCubeGrid GetBuiltGrid(long projectorId, int subgridIndex)
+        {
+            return (IMyCubeGrid) _miGetBuiltGrid?.Invoke(Api, new object[] {projectorId, subgridIndex});
+        }
+
+        public BlockState GetBlockState(long projectorId, int subgridIndex, Vector3I position)
+        {
+            return (BlockState) (_miGetBlockState?.Invoke(Api, new object[] {projectorId, subgridIndex, position}) ?? BlockState.Unknown);
+        }
+
+        public bool GetBlockStates(Dictionary<Vector3I, BlockState> blockStates, long projectorId, int subgridIndex, BoundingBoxI box, int mask)
+        {
+            return (bool) (_miGetBlockStates?.Invoke(Api, new object[] {blockStates, projectorId, subgridIndex, box, mask}) ?? false);
+        }
+
+        public Dictionary<Vector3I, BlockLocation> GetBaseConnections(long projectorId, int subgridIndex)
+        {
+            return (Dictionary<Vector3I, BlockLocation>) _miGetBaseConnections?.Invoke(Api, new object[] {projectorId, subgridIndex});
+        }
+
+        public Dictionary<Vector3I, BlockLocation> GetTopConnections(long projectorId, int subgridIndex)
+        {
+            return (Dictionary<Vector3I, BlockLocation>) _miGetTopConnections?.Invoke(Api, new object[] {projectorId, subgridIndex});
+        }
+    }
+}

--- a/BlockLimiter/Patch/BuildBlockPatch.cs
+++ b/BlockLimiter/Patch/BuildBlockPatch.cs
@@ -124,9 +124,9 @@ namespace BlockLimiter.Patch
             var projector = __instance;
             if (projector == null) return false;
 
-            if (owner + builder == 0) return false;
-
             if (!BlockLimiterConfig.Instance.EnableLimits) return true;
+
+            if (owner + builder == 0) return false;
 
             long projectorId = projector.EntityId;
             int subgridIndex = (int)builtBy;

--- a/BlockLimiter/Patch/BuildBlockPatch.cs
+++ b/BlockLimiter/Patch/BuildBlockPatch.cs
@@ -22,7 +22,7 @@ namespace BlockLimiter.Patch
     [PatchShim]
     public static class BuildBlockPatch
     {
-
+     
         public static void Patch(PatchContext ctx)
         {
             var t = typeof(MyCubeGrid);
@@ -35,7 +35,7 @@ namespace BlockLimiter.Patch
                 .Prefixes.Add(typeof(BuildBlockPatch).GetMethod(nameof(Build),
                     BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static));
         }
-
+     
 
         /// <summary>
         /// Checks blocks being built in creative with multiblock placement.
@@ -87,7 +87,7 @@ namespace BlockLimiter.Patch
         /// <returns></returns>
         private static bool BuildBlocksRequest(MyCubeGrid __instance, HashSet<MyCubeGrid.MyBlockLocation> locations)
         {
-
+            
             if (!BlockLimiterConfig.Instance.EnableLimits) return true;
 
             var grid = __instance;
@@ -101,8 +101,8 @@ namespace BlockLimiter.Patch
             var def = MyDefinitionManager.Static.GetCubeBlockDefinition(locations.FirstOrDefault().BlockDefinition);
 
             if (def == null) return true;
-
-
+            
+           
             var remoteUserId = MyEventContext.Current.Sender.Value;
             var playerId = Utilities.GetPlayerIdFromSteamId(remoteUserId);
 
@@ -156,7 +156,7 @@ namespace BlockLimiter.Patch
 
 
         }
-
+            
 
     }
 }


### PR DESCRIPTION
Utilizing the Multigrid Projector's API to find the right grid the block is built on and the right preview grid (projection) to get the block definition from.

Tested to work with both with and without the MGP Torch plugin loaded. Tested by GV admins on their test server. 

The API is forward compatible with all 0.* versions of the MGP.

[Multigrid Projector](https://steamcommunity.com/sharedfiles/filedetails/stats/2415983416) plugin