### PR TITLE
Fix crash when MyProjectorBase.Clipboard.CopiedGrids is null or has no elements

### DIFF
--- a/BlockLimiter/Patch/ProjectionPatch.cs
+++ b/BlockLimiter/Patch/ProjectionPatch.cs
@@ -56,7 +56,7 @@ namespace BlockLimiter.Patch
             var remoteUserId = MyEventContext.Current.Sender.Value;
             var grid = __instance.CubeGrid;
 
-            var copiedGrid = __instance.Clipboard.CopiedGrids[0];
+            var copiedGrid = __instance.Clipboard.CopiedGrids?.FirstOrDefault();
             
             if (copiedGrid == null || grid == null) return true;
 


### PR DESCRIPTION
This pr fixes a crash when list CopiedGrids is null or empty.