### PR TITLE
Fix `Utilities.GetDefinition()` caching logic failure given empty subtype id

### DIFF
--- a/BlockLimiter/Utility/Utilities.cs
+++ b/BlockLimiter/Utility/Utilities.cs
@@ -171,19 +171,11 @@ namespace BlockLimiter.Utility
             if (user == 0) return;
             ((MyMultiplayerServerBase)MyMultiplayer.Static).ValidationFailed(user);
         }
-        
-        private static MyConcurrentDictionary<MyStringHash, MyCubeBlockDefinition> _defCache = new MyConcurrentDictionary<MyStringHash, MyCubeBlockDefinition>();
 
         public static MyCubeBlockDefinition GetDefinition(MyObjectBuilder_CubeBlock block)
         {
-            if (_defCache.TryGetValue(block.SubtypeId, out var def))
-                return def;
-
-            var blockDefinition = MyDefinitionManager.Static.GetCubeBlockDefinition(block);
-            _defCache[block.SubtypeId] = blockDefinition;
-            return blockDefinition;
+            return MyDefinitionManager.Static.GetCubeBlockDefinition(block);
         }
-
 
         public static bool IsExcepted(object target)
         {


### PR DESCRIPTION
the initial code was caching definition structs based on their subtype id (not taking account of their type id), which was failing to handle block types that don't come with subtype id (eg. oxygen generator, gatling turrets, etc), which was causing grids to lose too many blocks when copy/pasted to the world via f10 and mods like "instant projector".

the fix is to stop caching the definition structs. i don't think caching is necessary here as far as the vanilla code goes: they do "new", but that's negligible for this size of struct, and taking the same struct out of a dictionary incurs about the same computational resource, because they have to be "new"ed out of the heap anyway.

there's another issue that i'm too lazy to make a ticket or fix now, but in `GridSpawnPatch.AttemptSpawn()`, a local variable `removalCount` is likely going to cause removal of too many blocks in case the value is incremented many times. i didn't fix it in this PR. 